### PR TITLE
add `--pre` for pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The REST API documentation can be found [on developers.cloudflare.com](https://d
 
 ```sh
 # install from PyPI
-pip install cloudflare
+pip install --pre cloudflare
 ```
 
 ## Usage


### PR DESCRIPTION
Updates the installation instructions to include `--pre` to get the right version.