### PR TITLE
fix: make the `name_servers` optional in zone

### DIFF
--- a/src/cloudflare/types/zones/zone.py
+++ b/src/cloudflare/types/zones/zone.py
@@ -78,7 +78,7 @@ class Zone(BaseModel):
     name: str
     """The domain name"""
 
-    name_servers: List[str]
+    name_servers: Optional[List[str]]
     """The name servers Cloudflare assigns to a zone"""
 
     original_dnshost: Optional[str] = None


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

In instances of [partial setup](https://developers.cloudflare.com/dns/zone-setups/partial-setup/setup/), zones might not have name servers configured. To be a bit more precise, the key "name_servers" is not present in the json for these zones. This results in a type error where an expected list is deserialized to None (when the key is not present).

This was discovered when fetching zones on an account and trying the json serialize and deserialize the result. The resulting process lead to an exception. My hypothesis is that this isn't doesn't result in an exception under normal operation because of the way that this classes are instantiated in this library bypasses type validation.

## Additional context & links
