### PR TITLE
Fix/pagination infinite loop

### DIFF
--- a/src/cloudflare/pagination.py
+++ b/src/cloudflare/pagination.py
@@ -84,6 +84,11 @@ class V4PagePaginationArrayResultInfo(BaseModel):
 
     per_page: Optional[int] = None
 
+    # Added missing fields present in V4 API
+    total_pages: Optional[int] = None
+    total_count: Optional[int] = None
+    count: Optional[int] = None
+
 
 class SyncV4PagePaginationArray(BaseSyncPage[_T], BasePage[_T], Generic[_T]):
     result: List[_T]
@@ -99,6 +104,10 @@ class SyncV4PagePaginationArray(BaseSyncPage[_T], BasePage[_T], Generic[_T]):
     @override
     def next_page_info(self) -> Optional[PageInfo]:
         last_page = cast("int | None", self._options.params.get("page")) or 1
+
+        # Guard against infinite loops where API returns data past the last page
+        if self.result_info and self.result_info.total_pages is not None and last_page >= self.result_info.total_pages:
+            return None
 
         return PageInfo(params={"page": last_page + 1})
 
@@ -118,6 +127,9 @@ class AsyncV4PagePaginationArray(BaseAsyncPage[_T], BasePage[_T], Generic[_T]):
     def next_page_info(self) -> Optional[PageInfo]:
         last_page = cast("int | None", self._options.params.get("page")) or 1
 
+        # Guard against infinite loops where API returns data past the last page
+        if self.result_info and self.result_info.total_pages is not None and last_page >= self.result_info.total_pages:
+            return None
         return PageInfo(params={"page": last_page + 1})
 
 

--- a/tests/test_pagination_fix.py
+++ b/tests/test_pagination_fix.py
@@ -1,0 +1,62 @@
+import pytest
+from cloudflare.pagination import AsyncV4PagePaginationArray, V4PagePaginationArrayResultInfo
+
+class MockOptions:
+    """Mock object to simulate the options/params passed to the paginator."""
+    def __init__(self, page_number: int):
+        self.params = {"page": page_number}
+
+@pytest.mark.asyncio
+async def test_async_pagination_stops_iteration_when_total_pages_reached() -> None:
+    """
+    Ensures the AsyncV4PagePaginationArray iterator correctly terminates when
+    the current page number matches the 'total_pages' field in the response metadata.
+    
+    This prevents infinite loops when the API returns the last page's data
+    repeatedly for out-of-bound page requests.
+    """
+    result_info = V4PagePaginationArrayResultInfo(
+        page=5,
+        per_page=20,
+        total_pages=5,
+        total_count=100,
+        count=20
+    )
+    
+    paginator = AsyncV4PagePaginationArray(
+        result=[], 
+        result_info=result_info
+    )
+    
+    # Manually inject private _options to simulate the current page state
+    object.__setattr__(paginator, "_options", MockOptions(page_number=5))
+    
+    next_info = paginator.next_page_info()
+    
+    assert next_info is None
+
+@pytest.mark.asyncio
+async def test_async_pagination_continues_when_more_pages_exist() -> None:
+    """
+    Ensures the iterator calculates the next page parameters correctly
+    when the current page is less than 'total_pages'.
+    """
+    result_info = V4PagePaginationArrayResultInfo(
+        page=1,
+        per_page=20,
+        total_pages=5, 
+        total_count=100,
+        count=20
+    )
+    
+    paginator = AsyncV4PagePaginationArray(
+        result=[],
+        result_info=result_info,
+    )
+    
+    object.__setattr__(paginator, "_options", MockOptions(page_number=1))
+    
+    next_info = paginator.next_page_info()
+    
+    assert next_info is not None
+    assert next_info.params["page"] == 2


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated, and my pull request may not be merged

## Changes being requested

This PR fixes a critical logic bug in `pagination.py` that causes infinite loops when iterating over results.

**The Bug:**
The `next_page_info` iterator blindly increments the page number even when the API returns the last page's data repeatedly for out-of-bounds requests (instead of 404s).

**The Fix:**
1.  Updated `Sync` and `Async` paginators to strictly stop iteration when `current_page >= total_pages`.
2.  Updated `V4PagePaginationArrayResultInfo` model to include the missing `total_pages`, `total_count`, and `count` fields so the SDK can correctly read the metadata.

**Verification:**
* Verified locally with a reproduction script against the live `client.accounts.list()` endpoint.
* Added unit tests in `tests/test_pagination_fix.py` to verify the logic in isolation.

## Additional context & links

Example codes to test:
```python
from cloudflare import Cloudflare, AsyncCloudflare

api_token = "redacted"
cloudflare = Cloudflare(api_token=api_token)

for account in cloudflare.accounts.list():
    print(account.name)

async_cloudflare = AsyncCloudflare(api_token=api_token)

async for account in async_cloudflare.accounts.list():
    print(account .name)
```

`It was looping indefinitely by printing the same account, but with my fix, the loop properly ends.`

**Note on CI:**
I noticed unrelated CI failures:
* `ImportError` in `radar` tests (circular imports upstream).
* `AuthenticationError` in `cloudforce_one` tests (upstream mock server auth).

My specific unit tests for pagination pass, and the formatting checks are green.

