### PR TITLE
fix: resolve type errors and Pydantic failures from codegen overwrites

### DIFF
--- a/src/cloudflare/resources/ai/to_markdown.py
+++ b/src/cloudflare/resources/ai/to_markdown.py
@@ -111,11 +111,11 @@ class ToMarkdownResource(SyncAPIResource):
         # sent to the server will contain a `boundary` parameter, e.g.
         # multipart/form-data; boundary=---abc--
         extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
-        return self._get_api_list(
+        return self._get_api_list(  # type: ignore[call-arg]
             path_template("/accounts/{account_id}/ai/tomarkdown", account_id=account_id),
             page=SyncSinglePage[ToMarkdownTransformResponse],
             body=maybe_transform(body, to_markdown_transform_params.ToMarkdownTransformParams),
-            files=files,
+            files=files,  # pyright: ignore[reportCallIssue]
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
@@ -210,11 +210,11 @@ class AsyncToMarkdownResource(AsyncAPIResource):
         # sent to the server will contain a `boundary` parameter, e.g.
         # multipart/form-data; boundary=---abc--
         extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
-        return self._get_api_list(
+        return self._get_api_list(  # type: ignore[call-arg]
             path_template("/accounts/{account_id}/ai/tomarkdown", account_id=account_id),
             page=AsyncSinglePage[ToMarkdownTransformResponse],
             body=maybe_transform(body, to_markdown_transform_params.ToMarkdownTransformParams),
-            files=files,
+            files=files,  # pyright: ignore[reportCallIssue]
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),

--- a/src/cloudflare/resources/organizations/organization_profile.py
+++ b/src/cloudflare/resources/organizations/organization_profile.py
@@ -19,7 +19,7 @@ from ..._response import (
 from ..._wrappers import ResultWrapper
 from ..._base_client import make_request_options
 from ...types.organizations import organization_profile_update_params
-from ...types.organizations.organization_profile_get_params import Result
+from ...types.organizations.organization_profile import OrganizationProfile as Result
 
 __all__ = ["OrganizationProfileResource", "AsyncOrganizationProfileResource"]
 

--- a/src/cloudflare/resources/radar/ai/to_markdown.py
+++ b/src/cloudflare/resources/radar/ai/to_markdown.py
@@ -88,11 +88,11 @@ class ToMarkdownResource(SyncAPIResource):
         # sent to the server will contain a `boundary` parameter, e.g.
         # multipart/form-data; boundary=---abc--
         extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
-        return self._get_api_list(
+        return self._get_api_list(  # type: ignore[call-arg]
             path_template("/accounts/{account_id}/ai/tomarkdown", account_id=account_id),
             page=SyncSinglePage[ToMarkdownCreateResponse],
             body=maybe_transform(body, to_markdown_create_params.ToMarkdownCreateParams),
-            files=extracted_files,  # pyright: ignore[reportCallIssue]  # type: ignore[call-arg]
+            files=extracted_files,  # pyright: ignore[reportCallIssue]
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
@@ -156,11 +156,11 @@ class AsyncToMarkdownResource(AsyncAPIResource):
         # sent to the server will contain a `boundary` parameter, e.g.
         # multipart/form-data; boundary=---abc--
         extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
-        return self._get_api_list(
+        return self._get_api_list(  # type: ignore[call-arg]
             path_template("/accounts/{account_id}/ai/tomarkdown", account_id=account_id),
             page=AsyncSinglePage[ToMarkdownCreateResponse],
             body=maybe_transform(body, to_markdown_create_params.ToMarkdownCreateParams),
-            files=extracted_files,  # pyright: ignore[reportCallIssue]  # type: ignore[call-arg]
+            files=extracted_files,  # pyright: ignore[reportCallIssue]
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),

--- a/src/cloudflare/types/ai/finetunes/asset_create_params.py
+++ b/src/cloudflare/types/ai/finetunes/asset_create_params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import TypedDict
+from typing_extensions import Required, TypedDict
 
 from ...._types import FileTypes
 

--- a/src/cloudflare/types/pipelines/sink_create_params.py
+++ b/src/cloudflare/types/pipelines/sink_create_params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Union, Iterable, Optional
+from typing import List, Union, Iterable, Optional
 from typing_extensions import Literal, Required, TypeAlias, TypedDict
 
 __all__ = [
@@ -290,12 +290,32 @@ class SchemaFieldJson(TypedDict, total=False):
     sql_name: str
 
 
-class SchemaFieldStruct(total=False):
-    pass
+class SchemaFieldStruct(TypedDict, total=False):
+    type: Required[Literal["struct"]]
+
+    metadata_key: Optional[str]
+
+    name: str
+
+    required: bool
+
+    sql_name: str
+
+    fields: Optional[List[object]]  # recursive SchemaField
 
 
-class SchemaFieldList(total=False):
-    pass
+class SchemaFieldList(TypedDict, total=False):
+    type: Required[Literal["list"]]
+
+    metadata_key: Optional[str]
+
+    name: str
+
+    required: bool
+
+    sql_name: str
+
+    element: Optional[object]  # recursive SchemaField
 
 
 SchemaField: TypeAlias = Union[

--- a/src/cloudflare/types/pipelines/sink_create_response.py
+++ b/src/cloudflare/types/pipelines/sink_create_response.py
@@ -276,12 +276,32 @@ class SchemaFieldJson(BaseModel):
     sql_name: Optional[str] = None
 
 
-class SchemaFieldStruct:
-    pass
+class SchemaFieldStruct(BaseModel):
+    type: Literal["struct"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    fields: Optional[List[object]] = None  # recursive SchemaField
 
 
-class SchemaFieldList:
-    pass
+class SchemaFieldList(BaseModel):
+    type: Literal["list"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    element: Optional[object] = None  # recursive SchemaField
 
 
 SchemaField: TypeAlias = Annotated[

--- a/src/cloudflare/types/pipelines/sink_get_response.py
+++ b/src/cloudflare/types/pipelines/sink_get_response.py
@@ -264,12 +264,32 @@ class SchemaFieldJson(BaseModel):
     sql_name: Optional[str] = None
 
 
-class SchemaFieldStruct:
-    pass
+class SchemaFieldStruct(BaseModel):
+    type: Literal["struct"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    fields: Optional[List[object]] = None  # recursive SchemaField
 
 
-class SchemaFieldList:
-    pass
+class SchemaFieldList(BaseModel):
+    type: Literal["list"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    element: Optional[object] = None  # recursive SchemaField
 
 
 SchemaField: TypeAlias = Annotated[

--- a/src/cloudflare/types/pipelines/sink_list_response.py
+++ b/src/cloudflare/types/pipelines/sink_list_response.py
@@ -264,12 +264,32 @@ class SchemaFieldJson(BaseModel):
     sql_name: Optional[str] = None
 
 
-class SchemaFieldStruct:
-    pass
+class SchemaFieldStruct(BaseModel):
+    type: Literal["struct"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    fields: Optional[List[object]] = None  # recursive SchemaField
 
 
-class SchemaFieldList:
-    pass
+class SchemaFieldList(BaseModel):
+    type: Literal["list"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    element: Optional[object] = None  # recursive SchemaField
 
 
 SchemaField: TypeAlias = Annotated[

--- a/src/cloudflare/types/pipelines/stream_create_params.py
+++ b/src/cloudflare/types/pipelines/stream_create_params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Union, Iterable, Optional
+from typing import List, Union, Iterable, Optional
 from typing_extensions import Literal, Required, TypeAlias, TypedDict
 
 from ..._types import SequenceNotStr
@@ -198,12 +198,32 @@ class SchemaFieldJson(TypedDict, total=False):
     sql_name: str
 
 
-class SchemaFieldStruct(total=False):
-    pass
+class SchemaFieldStruct(TypedDict, total=False):
+    type: Required[Literal["struct"]]
+
+    metadata_key: Optional[str]
+
+    name: str
+
+    required: bool
+
+    sql_name: str
+
+    fields: Optional[List[object]]  # recursive SchemaField
 
 
-class SchemaFieldList(total=False):
-    pass
+class SchemaFieldList(TypedDict, total=False):
+    type: Required[Literal["list"]]
+
+    metadata_key: Optional[str]
+
+    name: str
+
+    required: bool
+
+    sql_name: str
+
+    element: Optional[object]  # recursive SchemaField
 
 
 SchemaField: TypeAlias = Union[

--- a/src/cloudflare/types/pipelines/stream_create_response.py
+++ b/src/cloudflare/types/pipelines/stream_create_response.py
@@ -189,12 +189,32 @@ class SchemaFieldJson(BaseModel):
     sql_name: Optional[str] = None
 
 
-class SchemaFieldStruct:
-    pass
+class SchemaFieldStruct(BaseModel):
+    type: Literal["struct"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    fields: Optional[List[object]] = None  # recursive SchemaField
 
 
-class SchemaFieldList:
-    pass
+class SchemaFieldList(BaseModel):
+    type: Literal["list"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    element: Optional[object] = None  # recursive SchemaField
 
 
 SchemaField: TypeAlias = Annotated[

--- a/src/cloudflare/types/pipelines/stream_get_response.py
+++ b/src/cloudflare/types/pipelines/stream_get_response.py
@@ -189,12 +189,32 @@ class SchemaFieldJson(BaseModel):
     sql_name: Optional[str] = None
 
 
-class SchemaFieldStruct:
-    pass
+class SchemaFieldStruct(BaseModel):
+    type: Literal["struct"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    fields: Optional[List[object]] = None  # recursive SchemaField
 
 
-class SchemaFieldList:
-    pass
+class SchemaFieldList(BaseModel):
+    type: Literal["list"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    element: Optional[object] = None  # recursive SchemaField
 
 
 SchemaField: TypeAlias = Annotated[

--- a/src/cloudflare/types/pipelines/stream_list_response.py
+++ b/src/cloudflare/types/pipelines/stream_list_response.py
@@ -189,12 +189,32 @@ class SchemaFieldJson(BaseModel):
     sql_name: Optional[str] = None
 
 
-class SchemaFieldStruct:
-    pass
+class SchemaFieldStruct(BaseModel):
+    type: Literal["struct"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    fields: Optional[List[object]] = None  # recursive SchemaField
 
 
-class SchemaFieldList:
-    pass
+class SchemaFieldList(BaseModel):
+    type: Literal["list"]
+
+    metadata_key: Optional[str] = None
+
+    name: Optional[str] = None
+
+    required: Optional[bool] = None
+
+    sql_name: Optional[str] = None
+
+    element: Optional[object] = None  # recursive SchemaField
 
 
 SchemaField: TypeAlias = Annotated[

--- a/tests/api_resources/organizations/test_organization_profile.py
+++ b/tests/api_resources/organizations/test_organization_profile.py
@@ -9,7 +9,7 @@ import pytest
 
 from cloudflare import Cloudflare, AsyncCloudflare
 from tests.utils import assert_matches_type
-from cloudflare.types.organizations.organization_profile_get_params import Result
+from cloudflare.types.organizations.organization_profile import OrganizationProfile as Result
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 


### PR DESCRIPTION
## Summary

- **ai/finetunes/asset_create_params**: restore missing `Required` import dropped by codegen
- **organizations/organization_profile** + test: inline `Result` type alias after codegen deleted `organization_profile_get_params.py`
- **ai/to_markdown**, **radar/ai/to_markdown**: add `# type: ignore[call-arg]` on `_get_api_list()` call site for mypy; keep `# pyright: ignore` on `files=` kwarg
- **pipelines params** (sink_create_params, stream_create_params): restore `TypedDict` base class on `SchemaFieldStruct`/`SchemaFieldList` with `object` for recursive field refs
- **pipelines responses** (6 files): add `BaseModel` base class, `type` discriminator field, and standard fields to `SchemaFieldStruct`/`SchemaFieldList` stubs with `object` for recursive refs

## Context

All issues stem from the April 19-23 codegen runs (`3b83baa3b`, `0d6464258`, `988df8632`) overwriting earlier manual fixes (`1c415a2dd`, `f280942f4`). The pipelines recursive types use `object` instead of forward-referencing `"SchemaField"` to avoid Pydantic v2 `PydanticSchemaGenerationError` at module import time.

## Validation

```
pyright  -> 0 errors (was 55)
mypy     -> 0 errors (was 12)
ruff     -> pass
pytest   -> 39,931 passed, 14,255 skipped, 0 errors
             (was 51 failed + 36 errors before fix)
```

Remaining test failures (dns.records scan_list/scan_review, workers.beta.workers create/update) are mock server issues addressed in a separate cloudflare-config skip PR: https://gitlab.cfdata.org/cloudflare/sdks/cloudflare-config/-/merge_requests/730