### PR TITLE
ci: enable breaking change detection

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,7 +9,6 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    if: false
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

- Re-enables the `detect-breaking-changes` workflow by removing `if: false`
- Semgrep timeout was already at 25 minutes on `next`