### PR TITLE
Per-job permissions for publish-pypi, release-doctor, sync-labels

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   publish:
     name: publish
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   release_doctor:
     name: release doctor
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: github.repository == 'cloudflare/cloudflare-python' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please') || github.head_ref == 'next')

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -8,6 +8,8 @@ on:
       - .github/labels.yml
 jobs:
   build:
+    permissions:
+      issues: write   # action-label-syncer creates/updates repo labels
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Per-job `permissions` blocks on the three workflows still inheriting defaults:

- **publish-pypi.yml** — `contents: read`. The actual PyPI publish uses `PYPI_TOKEN` (or its Cloudflare-specific override), not the GitHub token. The runner only needs to check out the source.
- **release-doctor.yml** — `contents: read`. Just runs `./bin/check-release-environment` as a sanity check.
- **sync-labels.yml** — `issues: write`. `micnncim/action-label-syncer@v1` creates/updates labels via `GITHUB_TOKEN`; that endpoint is part of the issues API, so `issues: write` is the documented minimum.

Per-job style matches `ci.yml` (`contents: read` + `id-token: write`) and `detect-breaking-changes.yml` (`contents: read`). YAML validated.