### PR TITLE
ci: fail open on running example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
   examples:
     timeout-minutes: 10
     name: examples
+    continue-on-error: true
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.repository == 'cloudflare/cloudflare-python' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

The `example` CI job fails due to missing auth info.

```
cloudflare.BadRequestError: Error code: 400 - {'success': False, 'errors': [{'code': 9106, 'message': 'Missing X-Auth-Key, X-Auth-Email or Authorization headers'}], 'messages': [], 'result': None}
```

We can take a look at improving this later, but for now, I'm opting to not fail the workflow if this job fails.
