### PR TITLE
fix(ai): stop percent-encoding slashes in ai.run() model_name

### DIFF
--- a/src/cloudflare/_utils/_path.py
+++ b/src/cloudflare/_utils/_path.py
@@ -11,7 +11,12 @@ from urllib.parse import quote
 # Matches '.' or '..' where each dot is either literal or percent-encoded (%2e / %2E).
 _DOT_SEGMENT_RE = re.compile(r"^(?:\.|%2[eE]){1,2}$")
 
-_PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
+# A placeholder name may optionally be prefixed with '+', matching the RFC 6570
+# "reserved expansion" operator. This is used for path segments where the value
+# itself is allowed to contain additional '/' separators (e.g. AI model names
+# like `@cf/meta/llama-3.1-8b-instruct`).
+# https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.3
+_PLACEHOLDER_RE = re.compile(r"\{(\+?\w+)\}")
 
 
 def _quote_path_segment_part(value: str) -> str:
@@ -24,6 +29,17 @@ def _quote_path_segment_part(value: str) -> str:
     # as safe, so we only need to add sub-delims, ':', and '@'.
     # Notably, unlike the default `safe` for quote(), / is unsafe and must be quoted.
     return quote(value, safe="!$&'()*+,;=:@")
+
+
+def _quote_path_segment_part_reserved(value: str) -> str:
+    """Percent-encode `value` for use in a URI path segment, allowing '/' through unescaped.
+
+    Same as `_quote_path_segment_part` but additionally treats '/' as safe, per the
+    RFC 6570 reserved expansion operator (`{+name}`). Dot-segments are still rejected
+    by `path_template()` after interpolation, so this does not weaken path traversal
+    protection.
+    """
+    return quote(value, safe="!$&'()*+,;=:@/")
 
 
 def _quote_query_part(value: str) -> str:
@@ -48,10 +64,13 @@ def _interpolate(
     template: str,
     values: Mapping[str, Any],
     quoter: Callable[[str], str],
+    reserved_quoter: Callable[[str], str] | None = None,
 ) -> str:
     """Replace {name} placeholders in `template`, quoting each value with `quoter`.
 
-    Placeholder names are looked up in `values`.
+    Placeholder names are looked up in `values`. A placeholder written as `{+name}`
+    uses `reserved_quoter` instead of `quoter`, matching the RFC 6570 reserved
+    expansion operator (falls back to `quoter` if `reserved_quoter` is not given).
 
     Raises:
         KeyError: If a placeholder is not found in `values`.
@@ -61,22 +80,30 @@ def _interpolate(
     parts = _PLACEHOLDER_RE.split(template)
 
     for i in range(1, len(parts), 2):
-        name = parts[i]
+        raw_name = parts[i]
+        is_reserved = raw_name.startswith("+")
+        name = raw_name[1:] if is_reserved else raw_name
         if name not in values:
-            raise KeyError(f"a value for placeholder {{{name}}} was not provided")
+            raise KeyError(f"a value for placeholder {{{raw_name}}} was not provided")
         val = values[name]
         if val is None:
             parts[i] = "null"
         elif isinstance(val, bool):
             parts[i] = "true" if val else "false"
         else:
-            parts[i] = quoter(str(values[name]))
+            active_quoter = reserved_quoter if is_reserved and reserved_quoter is not None else quoter
+            parts[i] = active_quoter(str(val))
 
     return "".join(parts)
 
 
 def path_template(template: str, /, **kwargs: Any) -> str:
     """Interpolate {name} placeholders in `template` from keyword arguments.
+
+    A placeholder can be written as `{+name}` (RFC 6570 reserved expansion) in the
+    path portion of the template to allow the interpolated value to contain
+    additional unescaped `/` separators, for parameters whose values are themselves
+    composed of multiple path segments (e.g. AI model names).
 
     Args:
         template: The template string containing {name} placeholders.
@@ -107,7 +134,9 @@ def path_template(template: str, /, **kwargs: Any) -> str:
     path_template = rest
 
     # Interpolate each portion with the appropriate quoting rules.
-    path_result = _interpolate(path_template, kwargs, _quote_path_segment_part)
+    path_result = _interpolate(
+        path_template, kwargs, _quote_path_segment_part, reserved_quoter=_quote_path_segment_part_reserved
+    )
 
     # Reject dot-segments (. and ..) in the final assembled path.  The check
     # runs after interpolation so that adjacent placeholders or a mix of static

--- a/src/cloudflare/resources/ai/ai.py
+++ b/src/cloudflare/resources/ai/ai.py
@@ -991,7 +991,7 @@ class AIResource(SyncAPIResource):
             Optional[AIRunResponse],
             self._post(
                 path_template(
-                    "/accounts/{account_id}/ai/run/{model_name}", account_id=account_id, model_name=model_name
+                    "/accounts/{account_id}/ai/run/{+model_name}", account_id=account_id, model_name=model_name
                 ),
                 body=maybe_transform(
                     {
@@ -1971,7 +1971,7 @@ class AsyncAIResource(AsyncAPIResource):
             Optional[AIRunResponse],
             await self._post(
                 path_template(
-                    "/accounts/{account_id}/ai/run/{model_name}", account_id=account_id, model_name=model_name
+                    "/accounts/{account_id}/ai/run/{+model_name}", account_id=account_id, model_name=model_name
                 ),
                 body=await async_maybe_transform(
                     {

--- a/tests/test_utils/test_path.py
+++ b/tests/test_utils/test_path.py
@@ -54,6 +54,18 @@ from cloudflare._utils._path import path_template
         ),
         ("/v1/{val}", dict(val="x?admin=true"), "/v1/x%3Fadmin=true"),  # query injection
         ("/v1/{val}", dict(val="x#admin"), "/v1/x%23admin"),  # fragment injection
+        # Reserved expansion ({+name}): '/' is preserved in the path portion
+        (
+            "/accounts/{account_id}/ai/run/{+model_name}",
+            dict(account_id="a1", model_name="@cf/vendor/model"),
+            "/accounts/a1/ai/run/@cf/vendor/model",
+        ),
+        ("/v1/{+v}", dict(v="a/b/c"), "/v1/a/b/c"),
+        ("/v1/{+v}", dict(v="a b"), "/v1/a%20b"),  # other characters still escaped
+        ("/v1/{+v}", dict(v="a?b"), "/v1/a%3Fb"),  # '?' still escaped, only '/' is preserved
+        ("/v1/{+v}?q={v}", dict(v="a/b"), "/v1/a/b?q=a/b"),  # reserved flag only affects the path portion
+        ("/v1/{+v}", dict(v=None), "/v1/null"),
+        ("/v1/{+v}", dict(v=True), "/v1/true"),
     ],
 )
 def test_interpolation(template: str, kwargs: dict[str, Any], expected: str) -> None:
@@ -82,6 +94,8 @@ def test_missing_kwarg_raises_key_error() -> None:
         ("/v1/.%2E/{x}", dict(x="ok")),  # mixed encoded ".." in static
         ("/v1/{v}?q=1", dict(v="..")),
         ("/v1/{v}#frag", dict(v="..")),
+        ("/v1/{+v}", dict(v="..")),  # reserved expansion still rejects dot-segments
+        ("/v1/{+v}", dict(v="../../secret")),
     ],
 )
 def test_dot_segment_rejected(template: str, kwargs: dict[str, Any]) -> None:


### PR DESCRIPTION
Fixes #2718

client.ai.run() builds its request path with path_template(), which percent-encodes every character in a path placeholder, including forward slashes. Model names like `@cf/meta/llama-3.1-8b-instruct` end up in the URL as `@cf%2Fmeta%2Fllama-3.1-8b-instruct`, and the API responds with a 400 "No route for that URI". This broke every ai.run() call after the v5 rewrite, since v4.3.1 did not encode slashes this way.

Root cause is in `src/cloudflare/_utils/_path.py`. `path_template()` treats `/` as unsafe in the path portion (correct for a normal single path segment, since it protects against path traversal and segment confusion), but `model_name` is not a single path segment, it is a slash separated identifier that the Cloudflare API expects literally in the URL.

Fix: added support for RFC 6570 reserved expansion syntax in `path_template`. A placeholder written as `{+name}` keeps `/` unescaped in the interpolated value while still percent-encoding every other unsafe character, and the existing dot-segment rejection (`.` / `..`) still runs on the fully assembled path, so this does not weaken the path traversal protection that was added for the normal `{name}` syntax. Updated the `ai.run()` path template (both sync and async) to use `{+model_name}` instead of `{model_name}`.

I picked the reserved-expansion approach instead of a one-off hack in ai.py because this is a general problem: any path parameter that is itself a multi-segment identifier (this one, and potentially others in the future) needs the same treatment, and RFC 6570 already has a standard operator for exactly this.

Testing:
- Added test cases to `tests/test_utils/test_path.py` covering: the reported model_name case, that other special characters (space, `?`) are still escaped under `{+name}`, that the same variable used elsewhere in the same template without `+` is unaffected, and that dot-segment rejection still fires for `{+name}`.
- Ran the full `test_path.py` suite locally, 56 passed.
- Ran `ruff check` and `ruff format --diff` on the changed files, both clean.
- Manually reproduced the bug against the module directly before the fix (got `@cf%2Fblack-forest-labs%2Fflux-1-schnell`) and confirmed the fix produces `@cf/black-forest-labs/flux-1-schnell`.