### PR TITLE
fix(models): reject polymorphic_serialization on pydantic v1

### DIFF
--- a/src/cloudflare/_models.py
+++ b/src/cloudflare/_models.py
@@ -335,6 +335,8 @@ class BaseModel(pydantic.BaseModel):
                 raise ValueError("fallback is only supported in Pydantic v2")
             if exclude_computed_fields != False:
                 raise ValueError("exclude_computed_fields is only supported in Pydantic v2")
+            if polymorphic_serialization is not None:
+                raise ValueError("polymorphic_serialization is only supported in Pydantic v2")
             dumped = super().dict(  # pyright: ignore[reportDeprecated]
                 include=include,
                 exclude=exclude,
@@ -398,6 +400,8 @@ class BaseModel(pydantic.BaseModel):
                 raise ValueError("ensure_ascii is only supported in Pydantic v2")
             if exclude_computed_fields != False:
                 raise ValueError("exclude_computed_fields is only supported in Pydantic v2")
+            if polymorphic_serialization is not None:
+                raise ValueError("polymorphic_serialization is only supported in Pydantic v2")
             return super().json(  # type: ignore[reportDeprecated]
                 indent=indent,
                 include=include,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -537,6 +537,21 @@ def test_to_dict() -> None:
             m.to_dict(warnings=False)
 
 
+def test_polymorphic_serialization_is_rejected_on_pydantic_v1() -> None:
+    class Model(BaseModel):
+        foo: int = 1
+
+    m = Model()
+    if PYDANTIC_V1:
+        with pytest.raises(ValueError, match="polymorphic_serialization is only supported in Pydantic v2"):
+            m.model_dump(polymorphic_serialization=True)
+        with pytest.raises(ValueError, match="polymorphic_serialization is only supported in Pydantic v2"):
+            m.model_dump_json(polymorphic_serialization=True)
+
+    # the default must keep working on both major versions
+    assert m.model_dump() == {"foo": 1}
+
+
 def test_forwards_compat_model_dump_method() -> None:
     class Model(BaseModel):
         foo: Optional[str] = Field(alias="FOO", default=None)


### PR DESCRIPTION
On pydantic v1, `BaseModel` aliases the v2 method names and raises a clear `ValueError` for every option v1 cannot honour: `mode`, `round_trip`, `warnings`, `context`, `fallback`, `serialize_as_any`, `exclude_computed_fields`. `polymorphic_serialization` is the one exception. It sits in the signature of both `model_dump` and `model_dump_json` and is never read.

Measured, not eyeballed: of the 14 keyword-only parameters on `model_dump`, 13 are either forwarded to `super().dict()` or guarded by a raise. `polymorphic_serialization` is neither. Same in `model_dump_json`, 14 of 15.

So a v1 user who passes it gets no error and no effect, and the call looks like it worked. Every sibling in the same function tells them otherwise.

The fix adds the guard in the existing style, next to the `exclude_computed_fields` one, in both methods. Four lines.

Verified under pydantic 1.10.26, which is where the shim is actually live. The new test fails without the change with `DID NOT RAISE ValueError` and passes with it. `tests/test_models.py` is 46 passed and 13 skipped on v1, and 59 passed on pydantic v2 where the shim is inactive, so nothing regresses on the path most users are on. `ruff check` and `ruff format --check` are clean at the repo's own line length.

Note that this is low severity, it needs a v1 user who reaches for a fairly new pydantic option, and the consequence is a silently ignored argument, not wrong output. The argument for fixing it is consistency: thirteen neighbours already do the right thing.

I didn't check whether the generator would reintroduce it. CONTRIBUTING says manual modifications persist between generations, which is why I sent a patch instead of an issue, but I have not seen a regeneration happen.
